### PR TITLE
chore(update): org.gnome.Platform 43 and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = external/shared-modules
-	url = https://github.com/Grumbel/shared-modules.git

--- a/external/gtkmm.json
+++ b/external/gtkmm.json
@@ -1,0 +1,173 @@
+{
+    "//": "NB: all versions are pinned below a coordinated ABI break",
+    "name": "gtkmm",
+    "sources": [
+        {
+            "sha256": "1d7a35af9c5ceccacb244ee3c2deb9b245720d8510ac5c7e6f4b6f9947e6789c",
+            "type": "archive",
+            "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.7.tar.xz",
+            "x-checker-data": {
+                "type": "gnome",
+                "name": "gtkmm",
+                "versions": {
+                    "<": "3.25"
+                }
+            }
+        }
+    ],
+    "buildsystem": "meson",
+    "config-opts": [
+        "-Dmaintainer-mode=false",
+        "-Dbuild-demos=false",
+        "-Dbuild-tests=false"
+    ],
+    "cleanup": [
+        "*.a",
+        "*.la",
+        "/include",
+        "/lib/gdkmm-3.0",
+        "/lib/gtkmm-3.0",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/aclocal",
+        "/share/man",
+        "/share/pkgconfig"
+    ],
+    "modules": [
+        {
+            "name": "sigc++",
+            "sources": [
+                {
+                    "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a",
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libsigc++",
+                        "//": "later versions are incompatible with gtkmm3.24",
+                        "versions": {
+                            "<": "2.11"
+                        }
+                    }
+                }
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-examples=false"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/sigc++-2.0",
+                "/lib/pkgconfig",
+                "/lib/sigc++-2.0"
+            ]
+        },
+        {
+            "name": "glibmm",
+            "sources": [
+                {
+                    "sha256": "7b384662dd6ec3b86c0570331d32af05db2bd99a791602b767b4a0b2566ec149",
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.5.tar.xz",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "glibmm",
+                        "//": "later versions have ABI break",
+                        "versions": {
+                            "<": "2.67"
+                        }
+                    }
+                }
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-examples=false"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/glibmm-2.4",
+                "/include/giomm-2.4",
+                "/lib/glibmm-2.4",
+                "/lib/giomm-2.4",
+                "/lib/libglibmm_generate_extra_defs*",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "cairomm",
+            "sources": [
+                {
+                    "sha256": "4749d25a2b2ef67cc0c014caaf5c87fa46792fc4b3ede186fb0fc932d2055158",
+                    "type": "archive",
+                    "url": "https://www.cairographics.org/releases/cairomm-1.14.4.tar.xz",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 7959,
+                        "url-template": "https://www.cairographics.org/releases/cairomm-$version.tar.xz",
+                        "versions": {
+                            "<": "1.15"
+                        }
+                    }
+                }
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-examples=false"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/cairomm-1.0",
+                "/lib/cairomm-1.0",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "pangomm",
+            "sources": [
+                {
+                    "sha256": "410fe04d471a608f3f0273d3a17d840241d911ed0ff2c758a9859c66c6f24379",
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.3.tar.xz",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "pangomm",
+                        "versions": {
+                            "<": "2.47"
+                        }
+                    }
+                }
+            ],
+            "buildsystem": "meson",
+            "cleanup": [
+                "*.la",
+                "/include/pangomm-1.4",
+                "/lib/pangomm-1.4",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "atkmm",
+            "sources": [
+                {
+                    "sha256": "7c2088b486a909be8da2b18304e56c5f90884d1343c8da7367ea5cd3258b9969",
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.3.tar.xz",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "atkmm",
+                        "versions": {
+                            "<": "2.35"
+                        }
+                    }
+                }
+            ],
+            "buildsystem": "meson",
+            "cleanup": [
+                "*.la",
+                "/include/atkmm-1.6",
+                "/lib/atkmm-1.6",
+                "/lib/pkgconfig"
+            ]
+        }
+    ]
+}

--- a/io.gitlab.jstest_gtk.jstest_gtk.json
+++ b/io.gitlab.jstest_gtk.jstest_gtk.json
@@ -6,6 +6,7 @@
     "rename-icon": "jstest-gtk",
     "rename-desktop-file": "jstest-gtk.desktop",
     "rename-appdata-file": "jstest-gtk.appdata.xml",
+    "command": "jstest-gtk",
     "finish-args": [
         "--device=all",
         "--share=ipc",

--- a/io.gitlab.jstest_gtk.jstest_gtk.json
+++ b/io.gitlab.jstest_gtk.jstest_gtk.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.gitlab.jstest_gtk.jstest_gtk",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "rename-icon": "jstest-gtk",
     "rename-desktop-file": "jstest-gtk.desktop",

--- a/io.gitlab.jstest_gtk.jstest_gtk.json
+++ b/io.gitlab.jstest_gtk.jstest_gtk.json
@@ -14,12 +14,7 @@
         "--socket=session-bus"
     ],
     "modules": [
-        "external/shared-modules/sigc++/sigc++-2.0.json",
-        "external/shared-modules/glibmm/glibmm-2.4.json",
-        "external/shared-modules/cairomm/cairomm-1.0.json",
-        "external/shared-modules/pangomm/pangomm-1.4.json",
-        "external/shared-modules/atkmm/atkmm-1.6.json",
-        "external/shared-modules/gtkmm/gtkmm-3.24.2.json",
+        "external/gtkmm.json",
         {
             "name": "jstest-gtk",
             "buildsystem": "cmake-ninja",

--- a/io.gitlab.jstest_gtk.jstest_gtk.json
+++ b/io.gitlab.jstest_gtk.jstest_gtk.json
@@ -26,7 +26,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/jstest-gtk/jstest-gtk.git",
-                    "commit": "420317b412297929f7380259893e49e443450035"
+                    "commit": "8e84777a956068b76b293d91f03490140b744ace"
                 }
             ]
         }

--- a/io.gitlab.jstest_gtk.jstest_gtk.json
+++ b/io.gitlab.jstest_gtk.jstest_gtk.json
@@ -11,7 +11,8 @@
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
-        "--socket=session-bus"
+        "--filesystem=xdg-run/gvfsd", "--talk-name=org.gtk.vfs.*",
+        "--own-name=com.gmail.grumbel.jstest-gtk"
     ],
     "modules": [
         "external/gtkmm.json",


### PR DESCRIPTION
Also:
- build: Replace and update custom gtkmm build
- chore(update): Commit 8e84777a

Replace and update custom `gtkmm` build with recent flathub maintainers build, see: https://github.com/flathub/org.gnome.Gnote/blob/master/gtkmm.json.

Rationale for `gtkmm` update: must for new `org.gnome.Platform` >= `42` runtime.

`org.gnome.Platform 41` end of life soon so we must switch to supported version. Also hope this `gtkmm` build could save your time a little bit.